### PR TITLE
Update for latest clojuredocs.org site structure

### DIFF
--- a/resources/config.clj
+++ b/resources/config.clj
@@ -1,7 +1,7 @@
 {
 	:db-file-path "clojure-docs.docset/Contents/Resources/docSet.dsidx",
-	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure_core.html",
-	:httrack ["httrack" "http://clojuredocs.org/clojure_core" "-n" "--path" "httrack-clojuredocs.org"],
+	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure.html",
+	:httrack ["httrack" "http://clojuredocs.org/clojure.core" "-n" "--path" "httrack-clojuredocs.org"],
 	:docset-template "clojure-docs.docset/Contents/Resources/Documents",
 	:httrack-clojuredocs "httrack-clojuredocs.org/clojuredocs.org"
 }

--- a/src/clojuredocs_docset/core.clj
+++ b/src/clojuredocs_docset/core.clj
@@ -31,7 +31,7 @@
   (flush)))
 
 (defn mirror-clojuredocs []
-  (print-progress 15 "Mirroring clojuredocs.org/clojure_core")
+  (print-progress 15 (str "Mirroring " (second (:httrack conf))))
   (apply sh (:httrack conf)))
 
 (defn create-docset-template []
@@ -64,7 +64,7 @@
   (print-progress 75 "Generating index")
   (let [html-content (slurp (str user-dir "/" (:index-html-path conf)))
         document (Jsoup/parse html-content)
-        rows (map search-index-attributes (.select document ".function a"))]            
+        rows (map search-index-attributes (.select document ".dl-row .name a"))]
     (populate-search-index rows)))
 
 (defn generate-docset []


### PR DESCRIPTION
Can you double-check that I'm not misunderstanding something here? I'm pretty confident with the Jsoup change in `clojuredocs_docset/core.clj`, but not entirely confident about the `:httrack` value change in `config.clj`.

In any event, this does seem to generate a working docset for the `clojure.core` namespace, but that doesn't mean it's "right".
