### PR TITLE
Multiple HTML index file paths

### DIFF
--- a/resources/config.clj
+++ b/resources/config.clj
@@ -1,7 +1,7 @@
 {
 	:db-file-path "clojure-docs.docset/Contents/Resources/docSet.dsidx",
-	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure_core.html",
-	:httrack ["httrack" "http://clojuredocs.org/clojure_core" "-n" "--path" "httrack-clojuredocs.org"],
+	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure.html",
+	:httrack ["httrack" "http://clojuredocs.org/clojure.core" "-n" "--path" "httrack-clojuredocs.org"],
 	:docset-template "clojure-docs.docset/Contents/Resources/Documents",
 	:httrack-clojuredocs "httrack-clojuredocs.org/clojuredocs.org"
 }

--- a/resources/config.clj
+++ b/resources/config.clj
@@ -1,6 +1,6 @@
 {
 	:db-file-path "clojure-docs.docset/Contents/Resources/docSet.dsidx",
-	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure.html",
+	:index-html-paths ["clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure.html"],
 	:httrack ["httrack" "http://clojuredocs.org/clojure.core" "-n" "--path" "httrack-clojuredocs.org"],
 	:docset-template "clojure-docs.docset/Contents/Resources/Documents",
 	:httrack-clojuredocs "httrack-clojuredocs.org/clojuredocs.org"

--- a/src/clojuredocs_docset/core.clj
+++ b/src/clojuredocs_docset/core.clj
@@ -60,11 +60,17 @@
    :type "Function" 
    :path (str "clojuredocs.org/" (.attr element "href"))})
 
+(defn parse-path [index-html-path]
+  (let [parsed (->> index-html-path
+                    (str user-dir "/")
+                    slurp
+                    Jsoup/parse)]
+    (map search-index-attributes (.select parsed ".dl-row .name a"))))
+
 (defn generate-search-index []
   (print-progress 75 "Generating index")
-  (let [html-content (slurp (str user-dir "/" (:index-html-path conf)))
-        document (Jsoup/parse html-content)
-        rows (map search-index-attributes (.select document ".dl-row .name a"))]
+  (let [paths (:index-html-paths conf)
+        rows (mapcat parse-path paths)]
     (populate-search-index rows)))
 
 (defn generate-docset []

--- a/src/clojuredocs_docset/core.clj
+++ b/src/clojuredocs_docset/core.clj
@@ -31,7 +31,7 @@
   (flush)))
 
 (defn mirror-clojuredocs []
-  (print-progress 15 "Mirroring clojuredocs.org/clojure_core")
+  (print-progress 15 (str "Mirroring " (second (:httrack conf))))
   (apply sh (:httrack conf)))
 
 (defn create-docset-template []
@@ -64,7 +64,7 @@
   (print-progress 75 "Generating index")
   (let [html-content (slurp (str user-dir "/" (:index-html-path conf)))
         document (Jsoup/parse html-content)
-        rows (map search-index-attributes (.select document ".function a"))]            
+        rows (map search-index-attributes (.select document ".dl-row .name a"))]
     (populate-search-index rows)))
 
 (defn generate-docset []


### PR DESCRIPTION
This PR just changes the code to take a vector of paths instead of a single path, and updates the default `config.clj` accordingly.
