### PR TITLE
Update clojuredocs site structure for full index

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,8 +3,8 @@
   :url "http://github.com/dlokesh/clojuredocs-docset"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
-        				 [org.jsoup/jsoup "1.7.2"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
+        				 [org.jsoup/jsoup "1.8.3"]
         				 [org.clojure/java.jdbc "0.3.0-alpha4"]
         				 [org.xerial/sqlite-jdbc "3.7.2"]
                  [commons-io "2.4"]]

--- a/resources/config.clj
+++ b/resources/config.clj
@@ -1,6 +1,6 @@
 {
 	:db-file-path "clojure-docs.docset/Contents/Resources/docSet.dsidx",
-	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/clojure_core.html",
+	:index-html-path "clojure-docs.docset/Contents/Resources/Documents/clojuredocs.org/core-library/vars.html",
 	:httrack ["httrack" "http://clojuredocs.org/clojure_core" "-n" "--path" "httrack-clojuredocs.org"],
 	:docset-template "clojure-docs.docset/Contents/Resources/Documents",
 	:httrack-clojuredocs "httrack-clojuredocs.org/clojuredocs.org"

--- a/src/clojuredocs_docset/core.clj
+++ b/src/clojuredocs_docset/core.clj
@@ -58,17 +58,19 @@
 (defn search-index-attributes [element]
   {:name (.text element) 
    :type "Function" 
-   :path (str "clojuredocs.org/" (.attr element "href"))})
+   :path (str "clojuredocs.org" (subs (.attr element "href") 2))})
 
 (defn generate-search-index []
   (print-progress 75 "Generating index")
   (let [html-content (slurp (str user-dir "/" (:index-html-path conf)))
         document (Jsoup/parse html-content)
-        rows (map search-index-attributes (.select document ".function a"))]            
+        rows (map 
+               search-index-attributes 
+               (.select (.getAllElements document) ".col-sm-10 a"))]            
     (populate-search-index rows)))
 
 (defn generate-docset []
-  (mirror-clojuredocs)
+  ;(mirror-clojuredocs)
   (create-docset-template)
   (copy-html-to-docset)
   (clear-search-index)


### PR DESCRIPTION
Fixed the Site structure and allowed a full extraction of all vars listed on clojuredocs. Also updated two deps.
